### PR TITLE
HW templates: update namespaces for NIC templates

### DIFF
--- a/sites/example/hardware/machine/200/48/Dell2/32.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/32.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/32;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5e:88";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5e:86";

--- a/sites/example/hardware/machine/200/48/Dell2/33.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/33.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/33;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5e:79";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5e:77";

--- a/sites/example/hardware/machine/200/48/Dell2/34.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/34.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/34;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5d:70";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5d:6e";

--- a/sites/example/hardware/machine/200/48/Dell2/35.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/35.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/35;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5d:b1";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5d:af";

--- a/sites/example/hardware/machine/200/48/Dell2/36.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/36.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/36;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5e:b5";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5e:b3";

--- a/sites/example/hardware/machine/200/48/Dell2/37.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/37.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/37;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5d:a2";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5d:a0";

--- a/sites/example/hardware/machine/200/48/Dell2/38.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/38.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/38;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5d:34";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5d:32";

--- a/sites/example/hardware/machine/200/48/Dell2/39.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/39.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/39;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:ea:b0:10";
 "cards/nic/eth1/hwaddr" = "00:15:c5:ea:b0:0e";

--- a/sites/example/hardware/machine/200/48/Dell2/40.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/40.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/40;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:c5:eb:5c:76";
 "cards/nic/eth1/hwaddr" = "00:15:c5:eb:5c:74";

--- a/sites/example/hardware/machine/200/48/Dell2/41.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/41.pan
@@ -17,8 +17,8 @@ structure template hardware/machine/200/48/Dell2/41;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth0/hwaddr" = "00:15:C5:EB:5D:8E";
 "cards/nic/eth1/hwaddr" = "00:15:C5:EB:5D:8C";

--- a/sites/example/hardware/machine/200/48/Dell2/42.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/42.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/48/Dell2/42;
 
 "ram" = list(create("hardware/ram/generic", "size", 65536*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bnx2"),
-                    "eth1",create("hardware/nic/bnx2"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/bnx2"),
+                    "eth1",create("hardware/nic/by_driver/bnx2"));
 
 "cards/nic/eth0/hwaddr" = "00:15:C5:EB:5D:9A";
 "cards/nic/eth1/hwaddr" = "00:15:C5:EB:5D:9B";

--- a/sites/example/hardware/machine/200/48/Dell2/43.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/43.pan
@@ -16,9 +16,9 @@ structure template hardware/machine/200/48/Dell2/43;
 
 "ram" = list(create("hardware/ram/generic", "size", 65536*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bnx2"),
-                    "eth1",create("hardware/nic/bnx2"),
-                    "eth2",create("hardware/nic/bnx2"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/bnx2"),
+                    "eth1",create("hardware/nic/by_driver/bnx2"),
+                    "eth2",create("hardware/nic/by_driver/bnx2"));
 
 "cards/nic/eth0/hwaddr" = "00:15:C5:EB:5D:9C";
 "cards/nic/eth1/hwaddr" = "00:15:C5:EB:5D:9D";

--- a/sites/example/hardware/machine/200/48/Dell2/44.pan
+++ b/sites/example/hardware/machine/200/48/Dell2/44.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/48/Dell2/44;
 
 "ram" = list(create("hardware/ram/generic", "size", 262144*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bnx2x"),
-                    "eth1",create("hardware/nic/bnx2x"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/bnx2x"),
+                    "eth1",create("hardware/nic/by_driver/bnx2x"));
 
 "cards/nic/eth0/hwaddr" = "00:15:C5:EB:5D:A1";
 "cards/nic/eth1/hwaddr" = "00:15:C5:EB:5D:A2";

--- a/sites/example/hardware/machine/200/49/Hp1/30.pan
+++ b/sites/example/hardware/machine/200/49/Hp1/30.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/49/Hp1/30;
 
 "ram" = list(create("hardware/ram/generic", "size", 4096*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth1/hwaddr" = "00:00:1A:1A:3B:BB"; #me NIC2
 "cards/nic/eth0/hwaddr" = "00:00:1A:1A:3B:BA"; #me NIC1

--- a/sites/example/hardware/machine/200/49/Hp1/31.pan
+++ b/sites/example/hardware/machine/200/49/Hp1/31.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/49/Hp1/31;
 
 "ram" = list(create("hardware/ram/generic", "size", 4096*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth1/hwaddr" = "00:00:1A:1A:3B:CB"; #me NIC2
 "cards/nic/eth0/hwaddr" = "00:00:1A:1A:3B:CA"; #me NIC1

--- a/sites/example/hardware/machine/200/49/Hp1/32.pan
+++ b/sites/example/hardware/machine/200/49/Hp1/32.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/49/Hp1/32;
 
 "ram" = list(create("hardware/ram/generic", "size", 4096*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth1/hwaddr" = "00:00:1A:1A:3B:DB"; #me NIC2
 "cards/nic/eth0/hwaddr" = "00:00:1A:1A:3B:DA"; #me NIC1

--- a/sites/example/hardware/machine/200/49/Hp1/33.pan
+++ b/sites/example/hardware/machine/200/49/Hp1/33.pan
@@ -16,8 +16,8 @@ structure template hardware/machine/200/49/Hp1/33;
 
 "ram" = list(create("hardware/ram/generic", "size", 4096*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth1/hwaddr" = "00:00:1A:1A:3B:EB"; #me NIC2
 "cards/nic/eth0/hwaddr" = "00:00:1A:1A:3B:EA"; #me NIC1

--- a/sites/example/hardware/machine/200/49/Hp1/34.pan
+++ b/sites/example/hardware/machine/200/49/Hp1/34.pan
@@ -12,8 +12,8 @@ structure template hardware/machine/200/49/Hp1/34;
 
 "ram" = list(create("hardware/ram/generic", "size", 4096*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/tg3"),
-                    "eth1",create("hardware/nic/tg3"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/tg3"),
+                    "eth1",create("hardware/nic/by_driver/tg3"));
 
 "cards/nic/eth1/hwaddr" = "00:00:1A:1A:3B:EB"; #me NIC2
 "cards/nic/eth0/hwaddr" = "00:00:1A:1A:3B:EA"; #me NIC1

--- a/sites/example/hardware/machine/200/49/Ibm1/39.pan
+++ b/sites/example/hardware/machine/200/49/Ibm1/39.pan
@@ -19,8 +19,8 @@ structure template hardware/machine/200/49/Ibm1/39;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bcm5700"),
-                    "eth1",create("hardware/nic/bcm5700"));
+"cards/nic" = nlist("eth0",create("hardware/nic/broadcom/bcm5700"),
+                    "eth1",create("hardware/nic/broadcom/bcm5700"));
 
 "cards/nic/eth0/hwaddr" = "00:11:25:C4:21:02";
 "cards/nic/eth1/hwaddr" = "00:11:25:C4:21:03";

--- a/sites/example/hardware/machine/200/49/Ibm1/40.pan
+++ b/sites/example/hardware/machine/200/49/Ibm1/40.pan
@@ -19,8 +19,8 @@ structure template hardware/machine/200/49/Ibm1/40;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bcm5700"),
-                    "eth1",create("hardware/nic/bcm5700"));
+"cards/nic" = nlist("eth0",create("hardware/nic/broadcom/bcm5700"),
+                    "eth1",create("hardware/nic/broadcom/bcm5700"));
 
 "cards/nic/eth0/hwaddr" = "00:11:25:C4:21:02";
 "cards/nic/eth1/hwaddr" = "00:11:25:C4:21:03";

--- a/sites/example/hardware/machine/200/49/Ibm1/41.pan
+++ b/sites/example/hardware/machine/200/49/Ibm1/41.pan
@@ -19,8 +19,8 @@ structure template hardware/machine/200/49/Ibm1/41;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bcm5700"),
-                    "eth1",create("hardware/nic/bcm5700"));
+"cards/nic" = nlist("eth0",create("hardware/nic/broadcom/bcm5700"),
+                    "eth1",create("hardware/nic/broadcom/bcm5700"));
 
 "cards/nic/eth0/hwaddr" = "00:11:25:C4:21:02";
 "cards/nic/eth1/hwaddr" = "00:11:25:C4:21:03";

--- a/sites/example/hardware/machine/200/49/Ibm1/42.pan
+++ b/sites/example/hardware/machine/200/49/Ibm1/42.pan
@@ -14,8 +14,8 @@ structure template hardware/machine/200/49/Ibm1/42;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bcm5700"),
-                    "eth1",create("hardware/nic/bcm5700"));
+"cards/nic" = nlist("eth0",create("hardware/nic/broadcom/bcm5700"),
+                    "eth1",create("hardware/nic/broadcom/bcm5700"));
 
 "cards/nic/eth0/hwaddr" = "00:11:25:C4:21:02";
 "cards/nic/eth1/hwaddr" = "00:11:25:C4:21:03";

--- a/sites/example/hardware/machine/200/49/Ibm1/43.pan
+++ b/sites/example/hardware/machine/200/49/Ibm1/43.pan
@@ -14,8 +14,8 @@ structure template hardware/machine/200/49/Ibm1/43;
 
 "ram" = list(create("hardware/ram/generic", "size", 8192*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/bcm5700"),
-                    "eth1",create("hardware/nic/bcm5700"));
+"cards/nic" = nlist("eth0",create("hardware/nic/broadcom/bcm5700"),
+                    "eth1",create("hardware/nic/broadcom/bcm5700"));
 
 "cards/nic/eth0/hwaddr" = "00:11:25:C4:21:04";
 "cards/nic/eth1/hwaddr" = "00:11:25:C4:21:05";

--- a/sites/example/hardware/machine/one/base_not_so_small.pan
+++ b/sites/example/hardware/machine/one/base_not_so_small.pan
@@ -13,6 +13,8 @@ structure template hardware/machine/one/base_not_so_small;
 
 "ram" = list(create("hardware/ram/generic", "size", 4*GB));
 
-"cards/nic" = dict("eth0", create("hardware/nic/bnx2"), "eth1", create("hardware/nic/bnx2"),);
+"cards/nic" = dict("eth0", create("hardware/nic/by_driver/bnx2"),
+                   "eth1", create("hardware/nic/by_driver/bnx2"),
+                  );
 
 "cards/nic/eth0/boot" = true;

--- a/sites/example/hardware/machine/xen/base.pan
+++ b/sites/example/hardware/machine/xen/base.pan
@@ -17,7 +17,7 @@ structure template hardware/machine/xen/base;
 
 "ram" = list(create("hardware/ram/generic", "size", 256*MB));
 
-"cards/nic" = nlist("eth0",create("hardware/nic/xen_vif"));
+"cards/nic" = nlist("eth0",create("hardware/nic/by_driver/xen-netfront"));
 
 "cards/nic/eth0/hwaddr"              = undef;
 


### PR DESCRIPTION
- Reflect changes done in template-library-standard in 16.8.0
- Fixes #30

Ideally to be added to [16.8.0](https://github.com/quattor/release/issues/258).