### PR TITLE
Fix usage of onboot in examples

### DIFF
--- a/clusters/openstack/icehouse/profiles/compute-node.example.org.pan
+++ b/clusters/openstack/icehouse/profiles/compute-node.example.org.pan
@@ -23,32 +23,32 @@ include 'machine-types/openstack/compute_node';
 
 include 'components/network/config';
 
-'/system/network/interfaces/' = {
-  SELF[MGMT_INTERFACE] = dict(
-    'device',MGMT_INTERFACE,
-    'bootproto','dhcp',
-    'onboot', 'yes',
-    'type','Ethernet',
-  );
+'/system/network/interfaces' = {
+    SELF[MGMT_INTERFACE] = dict(
+        'device', MGMT_INTERFACE,
+        'bootproto', 'dhcp',
+        'onboot', 'yes',
+        'type', 'Ethernet',
+    );
 
-  SELF[DATA_BRIDGE] = dict(
-    'device',DATA_BRIDGE,
-    'type', 'OVSBridge',
-    'bootproto','static',
-    'ip','10.0.0.2',
-    'netmask','255.255.255.0',
-    'onboot','yes',
-  );
+    SELF[DATA_BRIDGE] = dict(
+        'device', DATA_BRIDGE,
+        'type', 'OVSBridge',
+        'bootproto', 'static',
+        'ip', '10.0.0.2',
+        'netmask', '255.255.255.0',
+        'onboot', 'yes',
+    );
 
-  SELF[DATA_INTERFACE] = dict(
-    'device',DATA_INTERFACE,
-    'type','OVSPort',
-    'bootproto','none',
-    'ovs_bridge',DATA_BRIDGE,
-    'onboot','yes',
-  );
+    SELF[DATA_INTERFACE] = dict(
+        'device', DATA_INTERFACE,
+        'type', 'OVSPort',
+        'bootproto', 'none',
+        'ovs_bridge', DATA_BRIDGE,
+        'onboot', 'yes',
+    );
 
-  SELF;
+    SELF;
 };
 
 #

--- a/clusters/openstack/icehouse/profiles/compute-node.example.org.pan
+++ b/clusters/openstack/icehouse/profiles/compute-node.example.org.pan
@@ -27,7 +27,7 @@ include 'components/network/config';
     SELF[MGMT_INTERFACE] = dict(
         'device', MGMT_INTERFACE,
         'bootproto', 'dhcp',
-        'onboot', 'yes',
+        'onboot', true,
         'type', 'Ethernet',
     );
 
@@ -37,7 +37,7 @@ include 'components/network/config';
         'bootproto', 'static',
         'ip', '10.0.0.2',
         'netmask', '255.255.255.0',
-        'onboot', 'yes',
+        'onboot', true,
     );
 
     SELF[DATA_INTERFACE] = dict(
@@ -45,7 +45,7 @@ include 'components/network/config';
         'type', 'OVSPort',
         'bootproto', 'none',
         'ovs_bridge', DATA_BRIDGE,
-        'onboot', 'yes',
+        'onboot', true,
     );
 
     SELF;

--- a/clusters/openstack/icehouse/profiles/network-node.example.org.pan
+++ b/clusters/openstack/icehouse/profiles/network-node.example.org.pan
@@ -1,11 +1,11 @@
 @maintainer{
-  name = Jerome Pansanel
-  email = jerome.pansanel@iphc.cnrs.fr
+name = Jerome Pansanel
+email = jerome.pansanel@iphc.cnrs.fr
 }
 
 @{
-  Example template that shows the configuration of an OpenStack Network 
-  node
+Example template that shows the configuration of an OpenStack Network
+node
 }
 
 object template network-node.example.org;
@@ -25,41 +25,41 @@ include 'machine-types/openstack/network_node';
 
 include 'components/network/config';
 
-'/system/network/interfaces/' = {
-  SELF[MGMT_INTERFACE] = dict(
-    'device',MGMT_INTERFACE,
-    'bootproto','dhcp',
-    'onboot', 'yes',
-    'type','Ethernet',
-  );
+'/system/network/interfaces' = {
+    SELF[MGMT_INTERFACE] = dict(
+        'device', MGMT_INTERFACE,
+        'bootproto', 'dhcp',
+        'onboot', 'yes',
+        'type', 'Ethernet',
+    );
 
-  SELF[PUBLIC_BRIDGE] = dict(
-    'device',DATA_BRIDGE,
-    'type','OVSBridge',
-    'bootproto','static',
-    'ip','192.168.10.32',
-    'netmask','255.255.255.0',
-    'onboot','yes',
-  );
+    SELF[PUBLIC_BRIDGE] = dict(
+        'device', DATA_BRIDGE,
+        'type', 'OVSBridge',
+        'bootproto', 'static',
+        'ip', '192.168.10.32',
+        'netmask', '255.255.255.0',
+        'onboot', 'yes',
+    );
 
-  SELF[PUBLIC_INTERFACE] = dict(
-    'device',PUBLIC_INTERFACE,
-    'type','OVSPort',
-    'bootproto','none',
-    'ovs_bridge',PUBLIC_BRIDGE,
-    'onboot','yes',
-  );
+    SELF[PUBLIC_INTERFACE] = dict(
+        'device', PUBLIC_INTERFACE,
+        'type', 'OVSPort',
+        'bootproto', 'none',
+        'ovs_bridge', PUBLIC_BRIDGE,
+        'onboot', 'yes',
+    );
 
-  SELF[DATA_BRIDGE] = dict(
-    'device',DATA_BRIDGE,
-    'type', 'OVSBridge',
-    'bootproto','static',
-    'ip','10.0.0.1',
-    'netmask','255.255.255.0',
-    'onboot','yes',
-  );
+    SELF[DATA_BRIDGE] = dict(
+        'device', DATA_BRIDGE,
+        'type', 'OVSBridge',
+        'bootproto', 'static',
+        'ip', '10.0.0.1',
+        'netmask', '255.255.255.0',
+        'onboot', 'yes',
+    );
 
-  SELF;
+    SELF;
 };
 
 #

--- a/clusters/openstack/icehouse/profiles/network-node.example.org.pan
+++ b/clusters/openstack/icehouse/profiles/network-node.example.org.pan
@@ -29,7 +29,7 @@ include 'components/network/config';
     SELF[MGMT_INTERFACE] = dict(
         'device', MGMT_INTERFACE,
         'bootproto', 'dhcp',
-        'onboot', 'yes',
+        'onboot', true,
         'type', 'Ethernet',
     );
 
@@ -39,7 +39,7 @@ include 'components/network/config';
         'bootproto', 'static',
         'ip', '192.168.10.32',
         'netmask', '255.255.255.0',
-        'onboot', 'yes',
+        'onboot', true,
     );
 
     SELF[PUBLIC_INTERFACE] = dict(
@@ -47,7 +47,7 @@ include 'components/network/config';
         'type', 'OVSPort',
         'bootproto', 'none',
         'ovs_bridge', PUBLIC_BRIDGE,
-        'onboot', 'yes',
+        'onboot', true,
     );
 
     SELF[DATA_BRIDGE] = dict(
@@ -56,7 +56,7 @@ include 'components/network/config';
         'bootproto', 'static',
         'ip', '10.0.0.1',
         'netmask', '255.255.255.0',
-        'onboot', 'yes',
+        'onboot', true,
     );
 
     SELF;


### PR DESCRIPTION
The update to the network component made backwards incompatible changes to the schema, in this case changing `onboot` from a string to a boolean, this means the examples need updating to build properly.